### PR TITLE
CU-86ayhxukt: Add a custome error class that works with scimaenaga exception handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ Scimaenaga.configure do |config|
 end
 ```
 
+To provide custom error responses use the `Scimaenaga::ExceptionHandler::CustomScimError` class, with an optional second parameter of the status code you'd like returned.
+
+```ruby
+raise Scimaenaga::ExceptionHandler::CustomScimError.new("Customer Error Response Details", 400)
+```
+
 ### Schemas endpoint
 
 If you need Schemas endpoint configure `schemas`.

--- a/lib/generators/scimaenaga/templates/initializer.rb
+++ b/lib/generators/scimaenaga/templates/initializer.rb
@@ -48,7 +48,7 @@ Scimaenaga.configure do |config|
   # For example, [:created_at, :id] or { created_at: :desc }.
   # config.scim_users_list_order = :id
 
-  # Hash of queryable attribtues on the user model. If
+  # Hash of queryable attributes on the user model. If
   # the attribute is not listed in this hash it cannot
   # be queried by this Gem. The structure of this hash
   # is { queryable_scim_attribute => user_attribute }.
@@ -57,6 +57,20 @@ Scimaenaga.configure do |config|
     givenName: :first_name,
     familyName: :last_name,
     email: :email,
+  }
+
+  # Hash of association models to the user. When needing to update user
+  # association models like an address then you can use this schema.
+  # The structure of this is:
+  # { association_name: { association_attribute: queryable_scim_attribute } }
+  config.user_association_schemas = {
+    address: {
+      helper_method: :scim_address,
+      line1: :streetAddress,
+      city: :locality,
+      state: :region,
+      zip: :postalCode
+    },
   }
 
   # Array of attributes that can be modified on the


### PR DESCRIPTION
## Why?

Want to be able to return appropriate status codes when using helper methods for SCIM.

## What?

Makes it so we can raise a custom error within our app that will be caught within the scimaenaga controller endpoints and return appropriate status codes along with helpful details.

## Caveats

Does not cover every status code available.

## Testing Notes

Raise a `Scimaenaga::ExceptionHandler::CustomScimError` with a message as first parameter and status code as second parameter.