### PR TITLE
CU-86ayp7vgu: Improve SCIM index filters

### DIFF
--- a/app/controllers/scimaenaga/scim_users_controller.rb
+++ b/app/controllers/scimaenaga/scim_users_controller.rb
@@ -12,7 +12,7 @@ module Scimaenaga
         users = @company
                 .public_send(Scimaenaga.config.scim_users_scope)
                 .where(
-                  "#{Scimaenaga.config.scim_users_model
+                  "#{Scimaenaga.config.scim_users_scope}.#{Scimaenaga.config.scim_users_model
               .connection.quote_column_name(query.attribute)} #{query.operator} ?",
                   query.parameter
                 )

--- a/app/models/scimaenaga/scim_query_parser.rb
+++ b/app/models/scimaenaga/scim_query_parser.rb
@@ -31,7 +31,29 @@ module Scimaenaga
       parameter = query_elements[2..-1].join(' ')
       return if parameter.blank?
 
-      parameter.gsub(/"/, '')
+      parameter.gsub!(/"/, '')
+
+      if operator == 'LIKE'
+        case query_elements[1]
+        when 'co'
+          "%#{parameter}%"
+        when 'sw'
+          "#{parameter}%"
+        when 'ew'
+          "%#{parameter}"
+        else
+          parameter
+        end
+      else
+        case parameter.downcase
+        when 'true'
+          true
+        when 'false'
+          false
+        else
+          parameter
+        end
+      end
     end
 
     private
@@ -40,6 +62,18 @@ module Scimaenaga
         case element
         when 'eq'
           '='
+        when 'ne'
+          '!='
+        when 'co', 'sw', 'ew'
+          'LIKE'
+        when 'gt'
+          '>'
+        when 'ge'
+          '>='
+        when 'lt'
+          '<'
+        when 'le'
+          '<='
         else
           # TODO: implement additional query filters
           raise Scimaenaga::ExceptionHandler::InvalidQuery

--- a/spec/models/scim_query_parser_spec.rb
+++ b/spec/models/scim_query_parser_spec.rb
@@ -26,4 +26,71 @@ describe Scimaenaga::ScimQueryParser do
       it { expect(parser.attribute).to eq :email }
     end
   end
+
+  describe '#operator' do
+    context 'eq' do
+      it { expect(parser.operator).to eq '=' }
+    end
+
+    context 'ne' do
+      described_class.new('userName ne "taro"', queryable_attributes)
+      it { expect(parser.operator).to eq '!=' }
+    end
+
+    context 'sw' do
+      described_class.new('userName sw "taro"', queryable_attributes)
+      it { expect(parser.operator).to eq 'LIKE' }
+    end
+
+    context 'gt' do
+      described_class.new('userName gt "taro"', queryable_attributes)
+      it { expect(parser.operator).to eq '>' }
+    end
+
+    context 'ge' do
+      described_class.new('userName ge "taro"', queryable_attributes)
+      it { expect(parser.operator).to eq '>=' }
+    end
+
+    context 'lt' do
+      described_class.new('userName lt "taro"', queryable_attributes)
+      it { expect(parser.operator).to eq '<' }
+    end
+
+    context 'le' do
+      described_class.new('userName le "taro"', queryable_attributes)
+      it { expect(parser.operator).to eq '<=' }
+    end
+  end
+
+  describe '#parameter' do
+    context 'no manipulation' do
+      it { expect(parser.perameter).to eq "taro" }
+    end
+
+    context 'Contains' do
+      described_class.new('userName co "taro"', queryable_attributes)
+      it { expect(parser.perameter).to eq '%taro%' }
+    end
+
+    context 'Starts with' do
+      described_class.new('userName sw "taro"', queryable_attributes)
+      it { expect(parser.perameter).to eq 'taro%' }
+    end
+
+    context 'Ends with' do
+      described_class.new('userName ew "taro"', queryable_attributes)
+      it { expect(parser.perameter).to eq '%taro' }
+    end
+
+    context 'True boolean' do
+      described_class.new('userName eq "True"', queryable_attributes)
+      it { expect(parser.perameter).to eq true }
+    end
+
+    context 'False boolean' do
+      described_class.new('userName eq "FALSE"', queryable_attributes)
+      it { expect(parser.perameter).to eq false }
+    end
+  end
 end


### PR DESCRIPTION
Currently the index only accounts for the `eq` operator. SCIM documentation lists many more options and this adds those options. This also adjusts parameter to account for `true` and `false`.

![Screenshot 2023-11-10 at 10 24 22 AM](https://github.com/eVisit/scimaenaga/assets/24964874/b48e9837-6609-4758-a8a5-6728bf86286c)