### PR TITLE
Patching AUP so extension attributes are mapped properly

### DIFF
--- a/app/libraries/scim_patch_operation_converter.rb
+++ b/app/libraries/scim_patch_operation_converter.rb
@@ -51,13 +51,19 @@ class ScimPatchOperationConverter
     private
 
       def convert_to_single_value_operations(op, path_base, hash_value)
-        hash_value.map do |k, v|
+        hash_value.flat_map do |k, v|
           path = if path_base.present?
                    "#{path_base}.#{k}"
                  else
                    k
                  end
-          fix_operation_format(op, path, v)
+
+          v = v.permit!.to_h if v.instance_of?(ActionController::Parameters)
+          if v.is_a?(Hash)
+            convert_to_single_value_operations(op, path, v)
+          else
+            [fix_operation_format(op, path, v)]
+          end
         end
       end
 

--- a/app/libraries/scim_patch_operation_user.rb
+++ b/app/libraries/scim_patch_operation_user.rb
@@ -39,11 +39,22 @@ class ScimPatchOperationUser < ScimPatchOperation
       #   filter: nil,
       #   rest_path: ['givenName']
       # }
-      attribute = path_scim[:attribute].to_sym
-      dig_keys = [attribute]
+      attribute = path_scim[:attribute]
+
+      # Handle SCIM extension URI paths (RFC 7644 Section 3.10)
+      # e.g., "urn:ietf:params:scim:schemas:extension:evisit:2.0:User:npi"
+      # parse_path_scim splits on '.' so the full colon-delimited URI+attribute
+      # arrives as a single attribute string; rest_path has any dot-separated
+      # sub-attributes that followed.
+      if attribute.start_with?('urn:')
+        return resolve_extension_path(attribute, path_scim[:rest_path])
+      end
+
+      attribute_sym = attribute.to_sym
+      dig_keys = [attribute_sym]
 
       if path_scim[:filter].present?
-        array_index = get_array_index(attribute, path_scim[:filter])
+        array_index = get_array_index(attribute_sym, path_scim[:filter])
         dig_keys << array_index if array_index.present?
       end
 
@@ -51,6 +62,33 @@ class ScimPatchOperationUser < ScimPatchOperation
 
       # *dig_keys example: emails, 0, value
       Scimaenaga.config.mutable_user_attributes_schema.dig(*dig_keys)
+    end
+
+    # Resolves a SCIM extension URI path to the corresponding model attribute
+    # by matching against String keys in mutable_user_attributes_schema.
+    #
+    # Extension paths use colon separators:
+    #   urn:ietf:params:scim:schemas:extension:evisit:2.0:User:npi
+    # The schema stores the URI portion as a String key:
+    #   "urn:ietf:params:scim:schemas:extension:evisit:2.0:User" => { npi: :npi, ... }
+    def resolve_extension_path(attribute_str, rest_path)
+      schema = Scimaenaga.config.mutable_user_attributes_schema
+
+      schema.each do |key, value|
+        next unless key.is_a?(String) && attribute_str.start_with?(key)
+        # Ensure match is at a URI boundary (exact match or followed by ':')
+        next unless attribute_str.length == key.length || attribute_str[key.length] == ':'
+
+        remainder = attribute_str.delete_prefix(key).delete_prefix(':')
+        dig_keys = []
+        dig_keys << remainder.to_sym if remainder.present?
+        dig_keys.concat(rest_path.map(&:to_sym)) if rest_path.present?
+
+        return value if dig_keys.empty?
+        return value.dig(*dig_keys) if value.is_a?(Hash)
+      end
+
+      nil
     end
 
     def get_array_index(attribute, filter)


### PR DESCRIPTION
Now, patch operations will be able to actually update if they change after the initial user is already mapped.